### PR TITLE
Fix possible crash in FindItemIndexInFixedSet.

### DIFF
--- a/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp
+++ b/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp
@@ -1781,10 +1781,14 @@ static int32 FindItemIndexInFixedSet(const TypedFixedSetAllocator<T>& set,
 {
 	if (set.GetCount())
 	{
-        const T* buffer = set.GetBuffer();
-		return set.GetIndex(std::lower_bound(
-								buffer, buffer + set.GetCount(), item,
-								T::Compare));
+		const T* buffer = set.GetBuffer();
+		const T* last = buffer + set.GetCount();
+		const T* found = std::lower_bound( buffer, buffer + set.GetCount(),
+											item, T::Compare);
+		if( found != last )
+		{
+			return set.GetIndex( found );
+		}
 	}
 	return -1;
 }


### PR DESCRIPTION
std::lower_bound() returns "last" when "item" isn't found. This fix avoids passing "last" to "set.GetIndex()".
