### PR TITLE
Fix for particle / fixture collision filtering.

### DIFF
--- a/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp
+++ b/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp
@@ -2771,64 +2771,84 @@ void b2ParticleSystem::SolveCollision(const b2TimeStep& step)
 	}
 	class SolveCollisionCallback : public b2FixtureParticleQueryCallback
 	{
+		// Call the contact filter if it's set, to determine whether to
+		// filter this contact.  Returns true if contact calculations should
+		// be performed, false otherwise.
+		inline bool ShouldCollide(b2Fixture * const fixture,
+								  int32 particleIndex)
+		{
+			if (m_contactFilter) {
+				const uint32* const flags = m_system->GetFlagsBuffer();
+				if (flags[particleIndex] & b2_fixtureContactFilterParticle) {
+					return m_contactFilter->ShouldCollide(fixture, m_system,
+														  particleIndex);
+				}
+			}
+			return true;
+		}
+
 		void ReportFixtureAndParticle(
 								b2Fixture* fixture, int32 childIndex, int32 a)
 		{
-			b2Body* body = fixture->GetBody();
-			b2Vec2 ap = m_system->m_positionBuffer.data[a];
-			b2Vec2 av = m_system->m_velocityBuffer.data[a];
-			b2RayCastOutput output;
-			b2RayCastInput input;
-			if (m_system->m_iterationIndex == 0)
-			{
-				// Put 'ap' in the local space of the previous frame
-				b2Vec2 p1 = b2MulT(body->m_xf0, ap);
-				if (fixture->GetShape()->GetType() == b2Shape::e_circle)
+			if (ShouldCollide(fixture, a)) {
+				b2Body* body = fixture->GetBody();
+				b2Vec2 ap = m_system->m_positionBuffer.data[a];
+				b2Vec2 av = m_system->m_velocityBuffer.data[a];
+				b2RayCastOutput output;
+				b2RayCastInput input;
+				if (m_system->m_iterationIndex == 0)
 				{
-					// Make relative to the center of the circle
-					p1 -= body->GetLocalCenter();
-					// Re-apply rotation about the center of the
-					// circle
-					p1 = b2Mul(body->m_xf0.q, p1);
-					// Subtract rotation of the current frame
-					p1 = b2MulT(body->m_xf.q, p1);
-					// Return to local space
-					p1 += body->GetLocalCenter();
+					// Put 'ap' in the local space of the previous frame
+					b2Vec2 p1 = b2MulT(body->m_xf0, ap);
+					if (fixture->GetShape()->GetType() == b2Shape::e_circle)
+					{
+						// Make relative to the center of the circle
+						p1 -= body->GetLocalCenter();
+						// Re-apply rotation about the center of the
+						// circle
+						p1 = b2Mul(body->m_xf0.q, p1);
+						// Subtract rotation of the current frame
+						p1 = b2MulT(body->m_xf.q, p1);
+						// Return to local space
+						p1 += body->GetLocalCenter();
+					}
+					// Return to global space and apply rotation of current frame
+					input.p1 = b2Mul(body->m_xf, p1);
 				}
-				// Return to global space and apply rotation of current frame
-				input.p1 = b2Mul(body->m_xf, p1);
-			}
-			else
-			{
-				input.p1 = ap;
-			}
-			input.p2 = ap + m_step.dt * av;
-			input.maxFraction = 1;
-			if (fixture->RayCast(&output, input, childIndex))
-			{
-				b2Vec2 n = output.normal;
-				b2Vec2 p =
-					(1 - output.fraction) * input.p1 +
-					output.fraction * input.p2 +
-					b2_linearSlop * n;
-				b2Vec2 v = m_step.inv_dt * (p - ap);
-				m_system->m_velocityBuffer.data[a] = v;
-				b2Vec2 f = m_step.inv_dt *
-					m_system->GetParticleMass() * (av - v);
-				m_system->ParticleApplyForce(a, f);
+				else
+				{
+					input.p1 = ap;
+				}
+				input.p2 = ap + m_step.dt * av;
+				input.maxFraction = 1;
+				if (fixture->RayCast(&output, input, childIndex))
+				{
+					b2Vec2 n = output.normal;
+					b2Vec2 p =
+						(1 - output.fraction) * input.p1 +
+						output.fraction * input.p2 +
+						b2_linearSlop * n;
+					b2Vec2 v = m_step.inv_dt * (p - ap);
+					m_system->m_velocityBuffer.data[a] = v;
+					b2Vec2 f = m_step.inv_dt *
+						m_system->GetParticleMass() * (av - v);
+					m_system->ParticleApplyForce(a, f);
+				}
 			}
 		}
 
 		b2TimeStep m_step;
+		b2ContactFilter* m_contactFilter;
 
 	public:
 		SolveCollisionCallback(
-			b2ParticleSystem* system, const b2TimeStep& step):
+			b2ParticleSystem* system, const b2TimeStep& step, b2ContactFilter* contactFilter) :
 			b2FixtureParticleQueryCallback(system)
 		{
 			m_step = step;
+			m_contactFilter = contactFilter;
 		}
-	} callback(this, step);
+	} callback(this, step, GetFixtureContactFilter());
 	m_world->QueryAABB(&callback, aabb);
 }
 


### PR DESCRIPTION
Feature to filter particles colliding with fixtures wasn't working correctly (e.g. using b2ContactFilter).

See discussion:
https://groups.google.com/forum/#!topic/liquidfun/TRHBLioVo-k

See bug:
bug: https://github.com/google/liquidfun/issues/40

I tracked down the issue to the SolveCollisionCallback class not correctly calling ShouldCollide(). SolveCollisionCallback code adjusts particles' velocities to avoid them passing through fixture boundaries in a single step. The resulting bug was that particles would get "stuck" to the edge of fixtures instead of passing through them.

This fix uses the same approach as the existing UpdateBodyContactsCallback class in the same file.
https://github.com/trophygeek/liquidfun/blob/particle-fixture-collision-fix-minimal/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L2638

The change is pretty minimal; however, tabbing in a large block of code makes it seem larger.

My original, full patch includes a new test, but I created this separate pull request with the minimal changes to fix the bug.  https://github.com/trophygeek/liquidfun/tree/particle-collision-filter-fix (branch includes a new test)

TomN (trophygeek)
