### PR TITLE
Win32 needs find_package(Threads) aswell

### DIFF
--- a/liquidfun/Box2D/CMakeLists.txt
+++ b/liquidfun/Box2D/CMakeLists.txt
@@ -37,6 +37,10 @@ if(CMAKE_CXX_COMPILER MATCHES ".*clang")
   # set_target_properties Can not find target to add properties to: Threads::Threads
   find_package(Threads)
 endif()
+if (WIN32)
+  find_package(Threads)
+endif()
+
 
 add_definitions( -DLIQUIDFUN_EXTERNAL_LANGUAGE_API=1 )
 


### PR DESCRIPTION
Fixes #30 

GCC (tested on Debian Wheezy) doesnt need it. Not sure if any other toolchain does.
