### PR TITLE
Finished JS bindings for basic collision filtering

### DIFF
--- a/liquidfun/Box2D/lfjs/Makefile
+++ b/liquidfun/Box2D/lfjs/Makefile
@@ -112,7 +112,8 @@ B2EDGESHAPE = \
 	'_b2EdgeShape_CreateFixture'
 
 B2FIXTURE = \
-	'_b2Fixture_TestPoint'
+	'_b2Fixture_TestPoint', \
+	'_b2Fixture_Refilter' \
 
 B2FRICTIONJOINT = \
 	'_b2FrictionJointDef_Create', \

--- a/liquidfun/Box2D/lfjs/jsBindings/Dynamics/b2Body.js
+++ b/liquidfun/Box2D/lfjs/jsBindings/Dynamics/b2Body.js
@@ -111,6 +111,7 @@ b2Body.prototype.CreateFixtureFromDef = function(fixtureDef) {
   fixture.body = this;
   b2World._Push(fixture, this.fixtures);
   world.fixturesLookup[fixture.ptr] = fixture;
+  fixture.SetFilterData(fixtureDef.filter);
   return fixture;
 };
 

--- a/liquidfun/Box2D/lfjs/jsBindings/Dynamics/b2Fixture.js
+++ b/liquidfun/Box2D/lfjs/jsBindings/Dynamics/b2Fixture.js
@@ -1,13 +1,16 @@
 /**@constructor*/
 function b2Filter() {
   this.categoryBits = 0x0001;
-  this.groupIndex = 0;
   this.maskBits = 0xFFFF;
+  this.groupIndex = 0;
 }
 
 // fixture globals
 var b2Fixture_isSensor_offset = Offsets.b2Fixture.isSensor;
 var b2Fixture_userData_offset = Offsets.b2Fixture.userData;
+var b2Fixture_filter_categoryBits_offset = Offsets.b2Fixture.filterCategoryBits;
+var b2Fixture_filter_maskBits_offset = Offsets.b2Fixture.filterMaskBits;
+var b2Fixture_filter_groupIndex_offset = Offsets.b2Fixture.filterGroupIndex;
 /**@constructor*/
 
 function b2Fixture() {
@@ -19,6 +22,8 @@ function b2Fixture() {
 
 var b2Fixture_TestPoint =
   Module.cwrap('b2Fixture_TestPoint', 'number', ['number', 'number', 'number']);
+var b2Fixture_Refilter =
+  Module.cwrap('b2Fixture_Refilter', 'null', ['number']);
 
 b2Fixture.prototype._SetPtr = function(ptr) {
   this.ptr = ptr;
@@ -39,8 +44,19 @@ b2Fixture.prototype.GetUserData = function() {
   return this.buffer.getUint32(b2Fixture_userData_offset, true);
 };
 
+b2Fixture.prototype.SetFilterData = function(filter) {
+  this.buffer.setUint16(b2Fixture_filter_categoryBits_offset, filter.categoryBits, true);
+  this.buffer.setUint16(b2Fixture_filter_maskBits_offset, filter.maskBits, true);
+  this.buffer.setUint16(b2Fixture_filter_groupIndex_offset, filter.groupIndex, true);
+  this.Refilter();
+};
+
 b2Fixture.prototype.SetSensor = function(flag) {
   this.buffer.setUint32(b2Fixture_isSensor_offset, flag, true);
+};
+
+b2Fixture.prototype.Refilter = function() {
+  b2Fixture_Refilter(this.ptr);
 };
 
 b2Fixture.prototype.TestPoint = function(p) {

--- a/liquidfun/Box2D/lfjs/jsBindings/Dynamics/b2FixtureJsBindings.cpp
+++ b/liquidfun/Box2D/lfjs/jsBindings/Dynamics/b2FixtureJsBindings.cpp
@@ -3,3 +3,7 @@
 double b2Fixture_TestPoint(void* fixture, double x, double y) {
   return (bool)((b2Fixture*)fixture)->TestPoint(b2Vec2(x,y));
 }
+
+void b2Fixture_Refilter(void* fixture) {
+  ((b2Fixture*)fixture)->Refilter();
+}

--- a/liquidfun/Box2D/lfjs/jsBindings/Dynamics/b2FixtureJsBindings.h
+++ b/liquidfun/Box2D/lfjs/jsBindings/Dynamics/b2FixtureJsBindings.h
@@ -3,5 +3,6 @@
 
 extern "C" {
 double b2Fixture_TestPoint(void* fixture, double x, double y);
+void b2Fixture_Refilter(void* fixture);
 }
 #endif

--- a/liquidfun/Box2D/lfjs/jsBindings/offsets.js
+++ b/liquidfun/Box2D/lfjs/jsBindings/offsets.js
@@ -61,6 +61,9 @@ var Offsets = {
     proxies: 24,
     proxyCount: 28,
     filter: 32,
+    filterCategoryBits: 32,
+    filterMaskBits: 34,
+    filterGroupIndex: 36,
     isSensor: 38,
     userData: 40
   },


### PR DESCRIPTION
This adds JavaScript bindings for b2Fixture.Refilter, and a JavaScript version of b2Fixture.SetFilterData. It also makes b2Body set the fixture's filter from the fixtureDef.
