### PR TITLE
Fix C++11 warning - left shift of signed value is undefined

### DIFF
--- a/liquidfun/Box2D/Box2D/Common/b2Settings.h
+++ b/liquidfun/Box2D/Box2D/Common/b2Settings.h
@@ -75,7 +75,7 @@ typedef unsigned long long uint64;
 // We expand the API so that other languages (e.g. Java) can call into
 // our C++ more easily. Only set if when the flag is not externally defined.
 #if !defined(LIQUIDFUN_EXTERNAL_LANGUAGE_API)
-#if SWIG || LIQUIDFUN_UNIT_TESTS
+#if defined(SWIG) || defined(LIQUIDFUN_UNIT_TESTS)
 #define LIQUIDFUN_EXTERNAL_LANGUAGE_API 1
 #else
 #define LIQUIDFUN_EXTERNAL_LANGUAGE_API 0

--- a/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp
+++ b/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp
@@ -52,7 +52,7 @@ static const uint32 yMask = ((1u << yTruncBits) - 1u) << yShift;
 static const uint32 xMask = ~yMask;
 static const uint32 relativeTagRight = 1u << xShift;
 static const uint32 relativeTagBottomLeft = (uint32)((1 << yShift) +
-                                                    (-1 << xShift));
+                                                    ((~uint32(0)) << xShift));
 
 static const uint32 relativeTagBottomRight = (1u << yShift) + (1u << xShift);
 

--- a/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.h
+++ b/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.h
@@ -23,7 +23,7 @@
 #include <Box2D/Particle/b2Particle.h>
 #include <Box2D/Dynamics/b2TimeStep.h>
 
-#if LIQUIDFUN_UNIT_TESTS
+#ifdef LIQUIDFUN_UNIT_TESTS
 #include <gtest/gtest.h>
 #endif // LIQUIDFUN_UNIT_TESTS
 


### PR DESCRIPTION
A couple of small tweaks that I needed for a clean compile in Clang with pedantic warnings