### PR TITLE
Add a b2Filter to b2ParticleSystemDef

### DIFF
--- a/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp
+++ b/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp
@@ -2511,14 +2511,34 @@ private:
 		return false;
 	}
 
+	// Return true if our particles can collide with this fixture
+	bool CanCollideWithFixture(b2Fixture* fixture)
+	{
+		if (fixture->IsSensor())
+		{
+			return false;
+		}
+
+		const b2Filter& filterA = fixture->GetFilterData();
+		const b2Filter& filterB = m_system->GetFilterData();
+		if (filterA.groupIndex == filterB.groupIndex && filterA.groupIndex != 0)
+		{
+			return filterA.groupIndex > 0;
+		}
+
+		bool collide = (filterA.maskBits & filterB.categoryBits) != 0 && (filterA.categoryBits & filterB.maskBits) != 0;
+		return collide;
+	}
+
 	// Receive a fixture and call ReportFixtureAndParticle() for each particle
 	// inside aabb of the fixture.
 	bool ReportFixture(b2Fixture* fixture)
 	{
-		if (fixture->IsSensor())
+		if (!CanCollideWithFixture(fixture))
 		{
 			return true;
 		}
+
 		const b2Shape* shape = fixture->GetShape();
 		int32 childCount = shape->GetChildCount();
 		for (int32 childIndex = 0; childIndex < childCount; childIndex++)

--- a/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.h
+++ b/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.h
@@ -21,6 +21,7 @@
 #include <Box2D/Common/b2SlabAllocator.h>
 #include <Box2D/Common/b2GrowableBuffer.h>
 #include <Box2D/Particle/b2Particle.h>
+#include <Box2D/Dynamics/b2Fixture.h>
 #include <Box2D/Dynamics/b2TimeStep.h>
 
 #if LIQUIDFUN_UNIT_TESTS
@@ -39,7 +40,6 @@ class b2BlockAllocator;
 class b2StackAllocator;
 class b2QueryCallback;
 class b2RayCastCallback;
-class b2Fixture;
 class b2ContactFilter;
 class b2ContactListener;
 class b2ParticlePairSet;
@@ -183,6 +183,9 @@ struct b2ParticleSystemDef
 	/// Enable strict Particle/Body contact check.
 	/// See SetStrictContactCheck for details.
 	bool strictContactCheck;
+
+	/// Contact filtering data.
+	b2Filter filter;
 
 	/// Set the particle density.
 	/// See SetDensity for details.
@@ -1006,6 +1009,9 @@ private:
 	float32 GetParticleMass() const;
 	float32 GetParticleInvMass() const;
 
+	// Get the filter mask, category and group bits
+	const b2Filter& GetFilterData() const;
+
 	// Get the world's contact filter if any particles with the
 	// b2_contactFilterParticle flag are present in the system.
 	b2ContactFilter* GetFixtureContactFilter() const;
@@ -1366,6 +1372,11 @@ inline float32 b2ParticleSystem::GetParticleInvMass() const
 	// mass = density * stride^2, so we take the inverse of this.
 	float32 inverseStride = m_inverseDiameter * (1.0f / b2_particleStride);
 	return m_inverseDensity * inverseStride * inverseStride;
+}
+
+inline const b2Filter& b2ParticleSystem::GetFilterData() const
+{
+	return m_def.filter;
 }
 
 inline b2Vec2* b2ParticleSystem::GetPositionBuffer()


### PR DESCRIPTION
This filter is applied to all fixtures before checking for
collisions with individual particles. This is more efficient
than b2_fixtureContactFilterParticle for skipping entire
classes of fixture/particle collisions.