### PR TITLE
Major fixes

### DIFF
--- a/liquidfun/Box2D/Box2D/Common/b2Settings.h
+++ b/liquidfun/Box2D/Box2D/Common/b2Settings.h
@@ -82,9 +82,11 @@ typedef unsigned long long uint64;
 #endif
 #endif
 
+
 /// @file
 /// Global tuning constants based on meters-kilograms-seconds (MKS) units.
 ///
+
 
 // Collision
 
@@ -196,6 +198,14 @@ typedef unsigned long long uint64;
 /// The time into the future that collisions against barrier particles will be detected.
 #define b2_barrierCollisionTime 2.5f
 
+/// Multiplier for the radius of a particle when colliding with a fixture.
+/// Originally the diameter was used, so a multiplier of 2 would restore that behaviour.
+#define b2_fixtureParticleCollisionRadiusScaler 1
+
+/// Prevents directional bias when solving elastic triads
+#define b2_elasticPreserveVelocity
+
+
 // Sleep
 
 /// The time that a body must be still before it will go to sleep.
@@ -206,6 +216,7 @@ typedef unsigned long long uint64;
 
 /// A body cannot sleep if its angular velocity is above this tolerance.
 #define b2_angularSleepTolerance	(2.0f / 180.0f * b2_pi)
+
 
 // Memory Allocation
 
@@ -236,8 +247,10 @@ void b2SetNumAllocs(const int32 numAllocs);
 /// Get number of calls to b2Alloc minus number of calls to b2Free.
 int32 b2GetNumAllocs();
 
+
 /// Logging function.
 void b2Log(const char* string, ...);
+
 
 /// Version numbering scheme.
 /// See http://en.wikipedia.org/wiki/Software_versioning

--- a/liquidfun/Box2D/Box2D/Dynamics/b2World.cpp
+++ b/liquidfun/Box2D/Box2D/Dynamics/b2World.cpp
@@ -1057,6 +1057,11 @@ void b2World::ClearForces()
 		body->m_force.SetZero();
 		body->m_torque = 0.0f;
 	}
+
+	for (b2ParticleSystem* p = m_particleSystemList; p; p = p->GetNext())
+	{
+		p->m_hasForce = false;
+	}
 }
 
 struct b2WorldQueryWrapper

--- a/liquidfun/Box2D/Box2D/Particle/b2ParticleGroup.cpp
+++ b/liquidfun/Box2D/Box2D/Particle/b2ParticleGroup.cpp
@@ -36,7 +36,9 @@ b2ParticleGroup::b2ParticleGroup()
 
 	m_timestamp = -1;
 	m_mass = 0;
+	m_invMass = 0;
 	m_inertia = 0;
+	m_invInertia = 0;
 	m_center = b2Vec2_zero;
 	m_linearVelocity = b2Vec2_zero;
 	m_angularVelocity = 0;
@@ -79,9 +81,12 @@ void b2ParticleGroup::UpdateStatistics() const
 		}
 		if (m_mass > 0)
 		{
-			m_center *= 1 / m_mass;
-			m_linearVelocity *= 1 / m_mass;
+			m_invMass = 1 / m_mass;
+			m_center *= m_invMass;
+			m_linearVelocity *= m_invMass;
 		}
+		else
+			m_invMass = 0;
 		m_inertia = 0;
 		m_angularVelocity = 0;
 		for (int32 i = m_firstIndex; i < m_lastIndex; i++)
@@ -93,8 +98,11 @@ void b2ParticleGroup::UpdateStatistics() const
 		}
 		if (m_inertia > 0)
 		{
-			m_angularVelocity *= 1 / m_inertia;
+			m_invInertia = 1 / m_inertia;
+			m_angularVelocity *= m_invInertia;
 		}
+		else
+			m_invInertia = 0;
 		m_timestamp = m_system->m_timestamp;
 	}
 }

--- a/liquidfun/Box2D/Box2D/Particle/b2ParticleGroup.h
+++ b/liquidfun/Box2D/Box2D/Particle/b2ParticleGroup.h
@@ -271,8 +271,8 @@ private:
 	b2ParticleGroup* m_next;
 
 	mutable int32 m_timestamp;
-	mutable float32 m_mass;
-	mutable float32 m_inertia;
+	mutable float32 m_mass, m_invMass;
+	mutable float32 m_inertia, m_invInertia;
 	mutable b2Vec2 m_center;
 	mutable b2Vec2 m_linearVelocity;
 	mutable float32 m_angularVelocity;


### PR DESCRIPTION
- Several major fixes to BeginContact and EndContact
- Makes fixture<->particle collision distance use radius instead of diameter, and if the extra distance was intentional, the setting b2_fixtureParticleCollisionRadiusScaler gives control over this instead of it being a constant 2.
- Makes b2ParticleSystem forces clear in b2World::ClearForces(), the same way that b2Body forces are cleared. This fixes forces from being applied at only the first particleIteration.
- SolveCollision and SolveBarrier relied on (delayed) forces to be cleared immediately, in order to generate the contacts they desire, so I added m_impulseBuffer for them to use, which clears immediately.
- Fixes elastic directional bias. I believe that this bias was more noticeable with smaller time steps.