### PR TITLE
Fix YouTube video embeds in documentation

### DIFF
--- a/liquidfun/Box2D/Documentation/index.html
+++ b/liquidfun/Box2D/Documentation/index.html
@@ -33,24 +33,24 @@
 <div class="textblock">
 <a name="Overview"><h2>Overview</h2></a>
 <p>LiquidFun is a 2D rigid-body and fluid simulation C++ library for games
-based upon <a href="http://box2d.org">Box2D</a>.  It provides support for
+based upon <a href="https://box2d.org">Box2D</a>.  It provides support for
 procedural animation of physical bodies to make objects move and interact in
 realistic ways.</p>
 
 <p>Stable releases of LiquidFun are available for download from
-<a href="http://github.com/google/liquidfun/releases">
+<a href="https://github.com/google/liquidfun/releases">
 github.com/google/liquidfun/releases</a>.</p>
 
 LiquidFun source code is available for download from
-<a href="http://github.com/google/liquidfun">github.com/google/liquidfun</a>.
+<a href="https://github.com/google/liquidfun">github.com/google/liquidfun</a>.
 </p>
 
 <p>Discuss LiquidFun with other developers and users on the
 <a href="http://groups.google.com/forum/#!forum/liquidfun">mailing list</a>.
 Report issues on the
-<a href="http://github.com/google/liquidfun/issues">issues tracker</a> or
+<a href="https://github.com/google/liquidfun/issues">issues tracker</a> or
 post your questions to
-<a href="http://stackoverflow.com">stackoverflow.com</a> tagged with
+<a href="https://stackoverflow.com/questions/tagged/liquidfun">stackoverflow.com</a> tagged with
 "<b>liquidfun</b>".</p>
 
 <a name="Testbed"><h2>Testbed</h2></a>
@@ -79,7 +79,7 @@ testbed program ported to JavaScript. It runs LiquidFun in your browser.
   <a href="Programmers-Guide.html">Programmer's Guide</a>.</li>
   <li><a href="SWIG.html">Java and SWIG</a>: How to use LiquidFun from Java
   via the <a href="http://www.swig.org">SWIG</a> bindings.</li>
-  <li><a href="http://docs.google.com/presentation/d/1fEAb4-lSyqxlVGNPog3G1LZ7UgtvxfRAwR0dwd19G4g/edit?usp=sharing">Inside LiquidFun</a>:
+  <li><a href="https://docs.google.com/presentation/d/1fEAb4-lSyqxlVGNPog3G1LZ7UgtvxfRAwR0dwd19G4g/edit?usp=sharing">Inside LiquidFun</a>:
   A presentation detailing the algorithms behind LiquidFun's particle
   simulation.</li>
 </ul>
@@ -87,7 +87,7 @@ testbed program ported to JavaScript. It runs LiquidFun in your browser.
 <a name="Trailer"><h2>Trailer</h2></a>
 
 <iframe width="560" height="315"
-  src="http://www.youtube.com/embed/yXLmdu810BQ?rel=0"
+  src="https://www.youtube.com/embed/yXLmdu810BQ?rel=0"
   frameborder="0" allowfullscreen onload="totop()"></iframe>
 
 <a name="Examples"><h2>Examples</h2></a>
@@ -100,34 +100,34 @@ the Testbed application.</p>
 <p>An initially rectangle shaped wall of water particles falling under gravity
 and crashing around a rectangular space.</p>
 <iframe width="560" height="315"
-  src="http://www.youtube.com/embed/fzhMGskzfdU?rel=0"
+  src="https://www.youtube.com/embed/fzhMGskzfdU?rel=0"
   frameborder="0" allowfullscreen onload="totop()"></iframe>
 
 <a name="ElasticParticles"><h3>Elastic Particles</h3></a>
 <p>Three groups of elastic particles interacting with a circular rigid body.
 </p>
 <iframe width="560" height="315"
-  src="http://www.youtube.com/embed/M8qrS-lh0Tg?rel=0"
+  src="https://www.youtube.com/embed/M8qrS-lh0Tg?rel=0"
   frameborder="0" allowfullscreen onload="totop()"></iframe>
 
 <a name="Particles"><h3>Particles</h3></a>
 <p>Water particles falling under gravity into a container with a circular rigid
 body displacing them.</p>
 <iframe width="560" height="315"
-  src="http://www.youtube.com/embed/Ht6cWDLD_Rk?rel=0"
+  src="https://www.youtube.com/embed/Ht6cWDLD_Rk?rel=0"
   frameborder="0" allowfullscreen onload="totop()"></iframe>
 
 <a name="SurfaceTension"><h3>Surface Tension</h3></a>
 <p>Three different colored groups of particles with surface tension
 demonstrating attraction and color mixing.</p>
 <iframe width="560" height="315"
-  src="http://www.youtube.com/embed/VJ_gPhHz3hI?rel=0"
+  src="https://www.youtube.com/embed/VJ_gPhHz3hI?rel=0"
   frameborder="0" allowfullscreen onload="totop()"></iframe>
 
 <a name="WaveMachine"><h3>Wave Machine</h3></a>
 <p>Water sloshing around an oscillating container.</p>
 <iframe width="560" height="315"
-  src="http://www.youtube.com/embed/QVDmDhu-bvg?rel=0"
+  src="https://www.youtube.com/embed/QVDmDhu-bvg?rel=0"
   frameborder="0" allowfullscreen onload="totop()"></iframe>
 
 <script>


### PR DESCRIPTION
The examples at https://google.github.io/liquidfun/#Examples do not load currently, because as the console reports:

```
Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure frame '<URL>'.
This request has been blocked; the content must be served over HTTPS.
```